### PR TITLE
chore(ai): track Claude files in stow config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "additionalDirectories": ["~/.agents"],
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
+  "forceLoginMethod": "console",
+  "permissions": {
+    "allow": [
+      "Bash(* --help *)",
+      "Bash(* --version)",
+      "Bash(cat *)",
+      "Bash(eza *)",
+      "Bash(find *)",
+      "Bash(gh *)",
+      "Bash(git *)",
+      "Bash(grep *)",
+      "Bash(ls *)",
+      "Bash(rg *)"
+    ],
+    "deny": ["Bash(git push *)"]
+  },
+  "syntaxHighlightingDisabled": false
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,16 +7,27 @@
   "forceLoginMethod": "console",
   "permissions": {
     "allow": [
-      "Bash(* --help *)",
-      "Bash(* --version)",
-      "Bash(cat *)",
       "Bash(eza *)",
       "Bash(find *)",
       "Bash(gh *)",
-      "Bash(git *)",
+      "Bash(git branch*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git show*)",
+      "Bash(git status*)",
       "Bash(grep *)",
       "Bash(ls *)",
       "Bash(rg *)"
+    ],
+    "ask": [
+      "Bash(git reset *)",
+      "Bash(git clean *)",
+      "Bash(git checkout *)",
+      "Bash(git switch *)",
+      "Bash(git restore *)",
+      "Bash(git rebase *)",
+      "Bash(git cherry-pick *)",
+      "Bash(git stash *)"
     ],
     "deny": ["Bash(git push *)"]
   },

--- a/.stow-local-ignore
+++ b/.stow-local-ignore
@@ -62,9 +62,7 @@ mise.local.toml
 
 # AI
 ^/AGENTS.*
-^/CLAUDE.*
 ^/\.ai
-^/\.claude
 
 # lefthook
 ^/\.lefthook

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Also look for skills in the @~/.agents directory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-Also look for skills in the @~/.agents directory
+In addition to the default directories, also look for skills in the local project @.agents and global @~/.agents directories.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-In addition to the default directories, also look for skills in the local project @.agents and global @~/.agents directories.
+Also look for skills in the local project @.agents and global @~/.agents directories, in addition to the default directories.


### PR DESCRIPTION
## Summary
- add Claude CLI configuration at `.claude/settings.json`
- add `CLAUDE.md` instruction file for skill discovery
- update `.stow-local-ignore` to stop excluding Claude files from stow tracking